### PR TITLE
HATEOAS依存設定がうまく行かない

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-hateoas</artifactId>
 		</dependency>
+		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
# 概要
pom.xmlにて以下を追記した所、`依存関係 'org.springframework.boot:spring-boot-starter-hateoas:2.7.3' が見つかりません`というエラーが出て、HATEOASを利用できない。

## 追記した内容
```		
<dependency>  
  <groupId>org.springframework.boot</groupId>  
  <artifactId>spring-boot-starter-hateoas</artifactId>  
</dependency>
``` 

## MavenRepository
https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-hateoas/2.7.3

# その他
[チュートリアルのこの部分を実行中](https://spring.pleiades.io/guides/tutorials/rest/#:~:text=%E3%83%8F%E3%82%A4%E3%83%91%E3%83%BC%E3%83%A1%E3%83%87%E3%82%A3%E3%82%A2%E9%A7%86%E5%8B%95%E5%9E%8B%E3%81%AE%E5%87%BA%E5%8A%9B%E3%81%AE%E4%BD%9C%E6%88%90%E3%82%92%E6%94%AF%E6%8F%B4%E3%81%99%E3%82%8B%E3%81%93%E3%81%A8%E3%82%92%E7%9B%AE%E7%9A%84%E3%81%A8%E3%81%97%E3%81%9F%20Spring%20%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%A7%E3%81%82%E3%82%8B%20Spring%20HATEOAS%20%E3%81%AE%E7%B4%B9%E4%BB%8B%E3%80%82%E3%82%B5%E3%83%BC%E3%83%93%E3%82%B9%E3%82%92%20RESTful%20%E3%81%AB%E3%82%A2%E3%83%83%E3%83%97%E3%82%B0%E3%83%AC%E3%83%BC%E3%83%89%E3%81%99%E3%82%8B%E3%81%AB%E3%81%AF%E3%80%81%E3%81%93%E3%82%8C%E3%82%92%E3%83%93%E3%83%AB%E3%83%89%E3%81%AB%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%BE%E3%81%99%E3%80%82)に発生した問題。