### PR TITLE
パスのIDに文字列を入れた時、404を返す実装

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/payroll/assembler/EmployeeModelAssembler.java
+++ b/src/main/java/payroll/assembler/EmployeeModelAssembler.java
@@ -1,12 +1,13 @@
 package payroll.assembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
-
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.server.RepresentationModelAssembler;
 import org.springframework.stereotype.Component;
 import payroll.controller.EmployeeController;
 import payroll.entity.Employee;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 /**
  * EmployeeエンティティをEmployeeエンティティモデルに変換するクラス

--- a/src/main/java/payroll/assembler/OrderModelAssembler.java
+++ b/src/main/java/payroll/assembler/OrderModelAssembler.java
@@ -1,13 +1,14 @@
 package payroll.assembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
-
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.server.RepresentationModelAssembler;
 import org.springframework.stereotype.Component;
 import payroll.controller.OrderController;
 import payroll.entity.Order;
 import payroll.enums.Status;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 /**
  * 注文エンティティを注文モデルに変換するクラス

--- a/src/main/java/payroll/controller/EmployeeController.java
+++ b/src/main/java/payroll/controller/EmployeeController.java
@@ -1,8 +1,5 @@
 package payroll.controller;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import net.bytebuddy.implementation.bytecode.Throw;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.CollectionModel;
@@ -16,6 +13,9 @@ import payroll.entity.Employee;
 import payroll.exception.EmployeeNotFoundException;
 import payroll.repository.EmployeeRepository;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
@@ -23,7 +23,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
  * 従業員モデル用コントローラ
  */
 @RestController
-@RequestMapping("/employees")
+//@RequestMapping("/employees")
 public class EmployeeController {
     /** DI:EmployeeRepository **/
     private final EmployeeRepository repository;
@@ -47,7 +47,7 @@ public class EmployeeController {
      * 従業員一覧取得
      * @return CollectionModel
      */
-    @GetMapping()
+    @GetMapping("/employees")
     public CollectionModel<EntityModel<Employee>> all() {
 
         List<EntityModel<Employee>> employees = repository.findAll().stream()
@@ -58,11 +58,25 @@ public class EmployeeController {
     }
 
     /**
+     * 従業員詳細取得
+     * @param id
+     * @return 従業員モデル
+     */
+    @GetMapping("/employees/{id:\\d+}")
+    public EntityModel<Employee> one(@PathVariable Long id) {
+
+        Employee employee = repository.findById(id)
+                .orElseThrow(() -> new EmployeeNotFoundException(id));
+
+        return assembler.toModel(employee);
+    }
+
+    /**
      * 従業員登録
      * @param newEmployee
      * @return 従業員エンティティ
      */
-    @PostMapping()
+    @PostMapping("/employees")
     public ResponseEntity<?> newEmployee(@RequestBody Employee newEmployee) {
 
         EntityModel<Employee> entityModel = assembler.toModel(repository.save(newEmployee));
@@ -77,26 +91,12 @@ public class EmployeeController {
     }
 
     /**
-     * 従業員詳細取得
-     * @param id
-     * @return 従業員モデル
-     */
-    @GetMapping("/{id:\\d+}")
-    public EntityModel<Employee> one(@PathVariable Long id) {
-
-        Employee employee = repository.findById(id)
-                .orElseThrow(() -> new EmployeeNotFoundException(id));
-
-        return assembler.toModel(employee);
-    }
-
-    /**
      * 従業員更新
      * @param newEmployee
      * @param id
      * @return 従業員エンティティ
      */
-    @PutMapping("/{id}")
+    @PutMapping("/employees/{id:\\d+}")
     public ResponseEntity<?> replaceEmployee(@RequestBody Employee newEmployee, @PathVariable Long id) {
 
         Employee updatedEmployee = repository.findById(id)
@@ -122,7 +122,7 @@ public class EmployeeController {
      * @param id
      * @return 従業員エンティティ
      */
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/employees/{id:\\d+}")
     public ResponseEntity<?> deleteEmployee(@PathVariable Long id) {
 
         repository.deleteById(id);

--- a/src/main/java/payroll/controller/EmployeeController.java
+++ b/src/main/java/payroll/controller/EmployeeController.java
@@ -81,7 +81,7 @@ public class EmployeeController {
      * @param id
      * @return 従業員モデル
      */
-    @GetMapping("/{id}")
+    @GetMapping("/{id:\\d+}")
     public EntityModel<Employee> one(@PathVariable Long id) {
 
         Employee employee = repository.findById(id)

--- a/src/main/java/payroll/controller/EmployeeController.java
+++ b/src/main/java/payroll/controller/EmployeeController.java
@@ -8,13 +8,8 @@ import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.IanaLinkRelations;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 import payroll.assembler.EmployeeModelAssembler;
 import payroll.entity.Employee;
 import payroll.exception.EmployeeNotFoundException;
@@ -27,6 +22,8 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
  * 従業員モデル用コントローラ
  */
 @RestController
+@RequestMapping("/employees")
+@Validated
 public class EmployeeController {
     /** DI:EmployeeRepository **/
     private final EmployeeRepository repository;
@@ -50,7 +47,7 @@ public class EmployeeController {
      * 従業員一覧取得
      * @return CollectionModel
      */
-    @GetMapping("/employees")
+    @GetMapping("/")
     public CollectionModel<EntityModel<Employee>> all() {
 
         List<EntityModel<Employee>> employees = repository.findAll().stream()
@@ -65,7 +62,7 @@ public class EmployeeController {
      * @param newEmployee
      * @return 従業員エンティティ
      */
-    @PostMapping("/employees")
+    @PostMapping("/")
     public ResponseEntity<?> newEmployee(@RequestBody Employee newEmployee) {
 
         EntityModel<Employee> entityModel = assembler.toModel(repository.save(newEmployee));
@@ -84,7 +81,7 @@ public class EmployeeController {
      * @param id
      * @return 従業員モデル
      */
-    @GetMapping("/employees/{id}")
+    @GetMapping("/{id}")
     public EntityModel<Employee> one(@PathVariable Long id) {
 
         Employee employee = repository.findById(id)
@@ -99,7 +96,7 @@ public class EmployeeController {
      * @param id
      * @return 従業員エンティティ
      */
-    @PutMapping("/employees/{id}")
+    @PutMapping("/{id}")
     public ResponseEntity<?> replaceEmployee(@RequestBody Employee newEmployee, @PathVariable Long id) {
 
         Employee updatedEmployee = repository.findById(id)
@@ -125,7 +122,7 @@ public class EmployeeController {
      * @param id
      * @return 従業員エンティティ
      */
-    @DeleteMapping("/employees/{id}")
+    @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteEmployee(@PathVariable Long id) {
 
         repository.deleteById(id);

--- a/src/main/java/payroll/controller/EmployeeController.java
+++ b/src/main/java/payroll/controller/EmployeeController.java
@@ -1,12 +1,10 @@
 package payroll.controller;
 
-import net.bytebuddy.implementation.bytecode.Throw;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.IanaLinkRelations;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import payroll.assembler.EmployeeModelAssembler;
 import payroll.entity.Employee;
@@ -23,7 +21,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
  * 従業員モデル用コントローラ
  */
 @RestController
-//@RequestMapping("/employees")
+@RequestMapping("/employees")
 public class EmployeeController {
     /** DI:EmployeeRepository **/
     private final EmployeeRepository repository;
@@ -47,7 +45,7 @@ public class EmployeeController {
      * 従業員一覧取得
      * @return CollectionModel
      */
-    @GetMapping("/employees")
+    @GetMapping
     public CollectionModel<EntityModel<Employee>> all() {
 
         List<EntityModel<Employee>> employees = repository.findAll().stream()
@@ -62,7 +60,7 @@ public class EmployeeController {
      * @param id
      * @return 従業員モデル
      */
-    @GetMapping("/employees/{id:\\d+}")
+    @GetMapping("/{id:\\d+}")
     public EntityModel<Employee> one(@PathVariable Long id) {
 
         Employee employee = repository.findById(id)
@@ -76,7 +74,7 @@ public class EmployeeController {
      * @param newEmployee
      * @return 従業員エンティティ
      */
-    @PostMapping("/employees")
+    @PostMapping
     public ResponseEntity<?> newEmployee(@RequestBody Employee newEmployee) {
 
         EntityModel<Employee> entityModel = assembler.toModel(repository.save(newEmployee));
@@ -96,7 +94,7 @@ public class EmployeeController {
      * @param id
      * @return 従業員エンティティ
      */
-    @PutMapping("/employees/{id:\\d+}")
+    @PutMapping("/{id:\\d+}")
     public ResponseEntity<?> replaceEmployee(@RequestBody Employee newEmployee, @PathVariable Long id) {
 
         Employee updatedEmployee = repository.findById(id)
@@ -122,7 +120,7 @@ public class EmployeeController {
      * @param id
      * @return 従業員エンティティ
      */
-    @DeleteMapping("/employees/{id:\\d+}")
+    @DeleteMapping("/{id:\\d+}")
     public ResponseEntity<?> deleteEmployee(@PathVariable Long id) {
 
         repository.deleteById(id);

--- a/src/main/java/payroll/controller/EmployeeController.java
+++ b/src/main/java/payroll/controller/EmployeeController.java
@@ -3,6 +3,7 @@ package payroll.controller;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import net.bytebuddy.implementation.bytecode.Throw;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
@@ -23,7 +24,6 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
  */
 @RestController
 @RequestMapping("/employees")
-@Validated
 public class EmployeeController {
     /** DI:EmployeeRepository **/
     private final EmployeeRepository repository;
@@ -47,7 +47,7 @@ public class EmployeeController {
      * 従業員一覧取得
      * @return CollectionModel
      */
-    @GetMapping("/")
+    @GetMapping()
     public CollectionModel<EntityModel<Employee>> all() {
 
         List<EntityModel<Employee>> employees = repository.findAll().stream()
@@ -62,7 +62,7 @@ public class EmployeeController {
      * @param newEmployee
      * @return 従業員エンティティ
      */
-    @PostMapping("/")
+    @PostMapping()
     public ResponseEntity<?> newEmployee(@RequestBody Employee newEmployee) {
 
         EntityModel<Employee> entityModel = assembler.toModel(repository.save(newEmployee));

--- a/src/main/java/payroll/controller/OrderController.java
+++ b/src/main/java/payroll/controller/OrderController.java
@@ -3,13 +3,11 @@ package payroll.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
-import org.springframework.hateoas.IanaLinkRelations;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.mediatype.problem.Problem;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Repository;
 import org.springframework.web.bind.annotation.*;
 import payroll.assembler.OrderModelAssembler;
 import payroll.entity.Order;
@@ -27,6 +25,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
  * 注文用コントローラ
  */
 @RestController
+@RequestMapping("/orders")
 public class OrderController {
     /** DI:orderRepository */
     private final OrderRepository orderRepository;
@@ -49,7 +48,7 @@ public class OrderController {
      * 一覧取得
      * @return 注文モデルのリスト
      */
-    @GetMapping("/orders")
+    @GetMapping
     public CollectionModel<EntityModel<Order>> all() {
 
         List<EntityModel<Order>> orders = orderRepository.findAll().stream()
@@ -71,7 +70,7 @@ public class OrderController {
      * @param id
      * @return 注文モデル
      */
-    @GetMapping("/orders/{id:\\d+}")
+    @GetMapping("/{id:\\d+}")
     public EntityModel<Order> one(@PathVariable Long id) {
 
         Order order = orderRepository.findById(id)
@@ -85,7 +84,7 @@ public class OrderController {
      * @param order
      * @return 注文エンティティ
      */
-    @PostMapping("/orders")
+    @PostMapping
     public ResponseEntity<EntityModel<Order>> newOrder(@RequestBody Order order) {
 
         order.setStatus(Status.IN_PROGRESS);
@@ -107,7 +106,7 @@ public class OrderController {
      * @param id
      * @return 注文エンティティ
      */
-    @DeleteMapping("/orders/{id:\\d+}/cancel")
+    @DeleteMapping("/{id:\\d+}/cancel")
     public ResponseEntity<?> cancel(@PathVariable Long id) {
 
         Order order = orderRepository.findById(id)
@@ -131,7 +130,7 @@ public class OrderController {
      * @param id
      * @return 注文エンティティ
      */
-    @PutMapping("/orders/{id:\\d+}/complete")
+    @PutMapping("/{id:\\d+}/complete")
     public ResponseEntity<?> complete(@PathVariable Long id) {
 
         Order order = orderRepository.findById(id)

--- a/src/main/java/payroll/controller/OrderController.java
+++ b/src/main/java/payroll/controller/OrderController.java
@@ -80,34 +80,6 @@ public class OrderController {
         return assembler.toModel(order);
     }
 
-    /* TODO: マージ前に削除すること */
-    /**
-     * 動作確認用PUTメソッド
-     * @param newOrder
-     * @param id
-     * @return ResponseEntity
-     */
-    @PutMapping("/orders/{id}")
-    public ResponseEntity<?> testPut(@RequestBody Order newOrder, @PathVariable Long id) {
-
-        Order updatedOrder = orderRepository.findById(id)
-            .map(order -> {
-                order.setDescription(newOrder.getDescription());
-                order.setStatus(newOrder.getStatus());
-                return orderRepository.save(order);
-            })
-            .orElseGet(() -> {
-                newOrder.setId(id);
-                return orderRepository.save(newOrder);
-                });
-
-            EntityModel<Order> entityModel = assembler.toModel(updatedOrder);
-
-        return ResponseEntity
-            .created(entityModel.getRequiredLink(IanaLinkRelations.SELF).toUri())
-            .body(entityModel);
-    }
-
     /**
      * 注文登録
      * @param order
@@ -135,7 +107,7 @@ public class OrderController {
      * @param id
      * @return 注文エンティティ
      */
-    @DeleteMapping("/orders/{id}/cancel")
+    @DeleteMapping("/orders/{id:\\d+}/cancel")
     public ResponseEntity<?> cancel(@PathVariable Long id) {
 
         Order order = orderRepository.findById(id)
@@ -159,7 +131,7 @@ public class OrderController {
      * @param id
      * @return 注文エンティティ
      */
-    @PutMapping("/orders/{id}/complete")
+    @PutMapping("/orders/{id:\\d+}/complete")
     public ResponseEntity<?> complete(@PathVariable Long id) {
 
         Order order = orderRepository.findById(id)

--- a/src/main/java/payroll/entity/Employee.java
+++ b/src/main/java/payroll/entity/Employee.java
@@ -2,8 +2,6 @@ package payroll.entity;
 
 import lombok.Data;
 
-import java.util.Objects;
-
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;

--- a/src/main/java/payroll/entity/Order.java
+++ b/src/main/java/payroll/entity/Order.java
@@ -3,8 +3,6 @@ package payroll.entity;
 import lombok.Data;
 import payroll.enums.Status;
 
-import java.util.Objects;
-
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;

--- a/src/main/java/payroll/exception/EmployeeNotFoundAdvice.java
+++ b/src/main/java/payroll/exception/EmployeeNotFoundAdvice.java
@@ -5,7 +5,6 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
-import payroll.exception.EmployeeNotFoundException;
 
 /**
  * 従業員検索エラー時の処理用クラス

--- a/src/main/java/payroll/exception/OrderNotFoundAdvice.java
+++ b/src/main/java/payroll/exception/OrderNotFoundAdvice.java
@@ -5,7 +5,6 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
-import payroll.exception.OrderNotFoundException;
 
 /**
  * 注文検索例外発生時の処理用クラス


### PR DESCRIPTION
# 概要
パスにIDを指定してGETする際、数値ではなく文字列を入れてGETしたとき404エラーを返す実装

# トラブル
実装時に以下トラブル発生（現在解決）
- @GetMappingにプレースホルダ`{id:\\d+}`を記述し、GETすると、405エラーとなる

# 原因
同じパスを使う、他のHTTPメソッド（PUT,DELETE）に同じプレースホルダが無かったため

# 対処
- GetMappingで指定したパス`employees/{id}`と同じパスに、異なるHTTPメソッドでアクセスするように指定している箇所`@|Put|Delete|Mapping("employees/{id}")`も、どうように`{id:\\d+}`を記述すると解消した。
※Orderコントローラも同様に実装

# テスト
①Employeeコントローラで再現
- EmployeeController.javaの`Put|Delete|Mapping("employees/{id}")`の`{id}`部分に`id:\\d+'をつけずにGETメソッド実行→405
- つけて再度GETメソッド事項→404

②Orderコントローラでも同様の事象が起きること確認
- OrderController.javaに以下メソッドを追記
- GETメソッドで、`http://localhost:8080/orders/test`とすると405が返ってくる
- @PutMapping("/orders/{id}")の{id}を`{id:\\d+}`とし、もう一度GETメソッドを実行すると404となる。

```
/**
     * 動作確認用PUTメソッド
     * @param newOrder
     * @param id
     * @return ResponseEntity
     */
    @PutMapping("/orders/{id}")
    public ResponseEntity<?> testPut(@RequestBody Order newOrder, @PathVariable Long id) {

        Order updatedOrder = orderRepository.findById(id)
            .map(order -> {
                order.setDescription(newOrder.getDescription());
                order.setStatus(newOrder.getStatus());
                return orderRepository.save(order);
            })
            .orElseGet(() -> {
                newOrder.setId(id);
                return orderRepository.save(newOrder);
                });

            EntityModel<Order> entityModel = assembler.toModel(updatedOrder);

        return ResponseEntity
            .created(entityModel.getRequiredLink(IanaLinkRelations.SELF).toUri())
            .body(entityModel);
    }

```